### PR TITLE
Changes to let align3d operate on data with differing GSDs (Issue #16)

### DIFF
--- a/src/align3d/align3d.cpp
+++ b/src/align3d/align3d.cpp
@@ -25,10 +25,10 @@ namespace align3d {
 
             // Map the point into the target.
             // Skip if this isn't a valid point.
-            long col = long((x - targetDSM.easting + dx) / targetDSM.gsd + 0.5);
-            long row = targetDSM.height - 1 - long((y - targetDSM.northing + dy) / targetDSM.gsd + 0.5);
-            if (col <= 0) continue;
-            if (row <= 0) continue;
+            long col = long((x - targetDSM.easting + dx) / targetDSM.gsd);
+            long row = targetDSM.height - 1 - long((y - targetDSM.northing + dy) / targetDSM.gsd);
+            if (col < 0) continue;
+            if (row < 0) continue;
             if (col >= targetDSM.width - 1) continue;
             if (row >= targetDSM.height - 1) continue;
             if (targetDSM.data[row][col] == 0) continue;
@@ -36,10 +36,10 @@ namespace align3d {
 
             // Map the point into the reference.
             // Skip if this isn't a valid point.
-            col = long((x - referenceDSM.easting) / referenceDSM.gsd + 0.5);
-            row = referenceDSM.height - 1 - long((y - referenceDSM.northing) / referenceDSM.gsd + 0.5);
-            if (col <= 0) continue;
-            if (row <= 0) continue;
+            col = long((x - referenceDSM.easting) / referenceDSM.gsd);
+            row = referenceDSM.height - 1 - long((y - referenceDSM.northing) / referenceDSM.gsd);
+            if (col < 0) continue;
+            if (row < 0) continue;
             if (col >= referenceDSM.width - 1) continue;
             if (row >= referenceDSM.height - 1) continue;
             if (referenceDSM.data[row][col] == 0) continue;
@@ -201,10 +201,6 @@ namespace align3d {
 		if (!ok) {
 			// If not a point cloud, then try to read as GeoTIFF.
 			ok = targetDSM.read(targetFileName);
-			if (ok && targetDSM.gsd != params.gsd) {
-				ok = false;
-				printf("Input files are GeoTIFF and point spacing does not match.\n");
-			}
 		}
         if (!ok) {
             printf("Failed to read %s\n", targetFileName);

--- a/src/align3d/main.cpp
+++ b/src/align3d/main.cpp
@@ -2,13 +2,14 @@
 // Licensed under the MIT License. See LICENSE.txt in the project root for full license information.
 
 #include "align3d.h"
+#include <chrono>
 
 void printArguments();
 
 // Main program for simple 3d alignment.
 int main(int argc, char **argv) {
     // If no parameters, then print command line arguments.
-    if (argc < 4) {
+    if (argc < 3) {
         printf("\nNumber of arguments = %d\n", argc);
         for (int i = 1; i < argc; i++) {
             printf("  ARG[%d] = %s\n", i, argv[i]);
@@ -43,8 +44,7 @@ int main(int argc, char **argv) {
     printf("  maxt  = %f\n", params.maxt);
 
     // Initialize the timer.
-    time_t t0;
-    time(&t0);
+    std::chrono::steady_clock::time_point t0 = std::chrono::steady_clock::now();
 
     try {
         // Align the target point cloud to the reference.
@@ -53,9 +53,8 @@ int main(int argc, char **argv) {
         std::cerr << "Reporting error: " << err << std::endl;
     }
     // Report total elapsed time.
-    time_t t1;
-    time(&t1);
-    printf("Total time elapsed = %f seconds\n", double(t1 - t0));
+    std::chrono::steady_clock::time_point t1 = std::chrono::steady_clock::now();
+    printf("Total time elapsed = %f seconds\n", std::chrono::duration<double>(t1-t0).count());
 
     return 0;
 }
@@ -64,9 +63,9 @@ int main(int argc, char **argv) {
 void printArguments() {
     printf("Command Line: align3d <reference> <target> <parameters>\n");
     printf("Parameters:\n");
-    printf("  maxdz= Max local Z difference (meters) for matching\n");
-    printf("  gsd=   Ground Sample Distance (GSD) for gridding (meters)\n");
-    printf("  maxt=	 Maximum horizontal translation in search (meters); default = 10.0\n");
+    printf("  gsd=   Ground Sample Distance (GSD) for gridding point cloud (meters); default = 1.0\n");
+    printf("  maxdz= Max local Z difference (meters) for matching; default = 2*gsd\n");
+    printf("  maxt=  Maximum horizontal translation in search (meters); default = 10.0\n");
     printf("Examples:\n");
     printf("  align3d ref.las tgt.las maxt=10.0 gsd=0.5 maxdz=0.5\n\n");
 }


### PR DESCRIPTION
Changes include:
 o  Removing GSD restriction
 o  Correcting row/col calculation that was adding bias to results when
    different GSDs were used
 o  Letting data from row/col==0 be used for registration
 o  Fixed timing (allowing for fractional seconds)
 o  Addressed command line arguments (better descriptions, and allowing use of
    default parameters)