### PR TITLE
Fix writing offsets text file

### DIFF
--- a/src/align3d/align3d.cpp
+++ b/src/align3d/align3d.cpp
@@ -236,7 +236,7 @@ namespace align3d {
         char outFileName[1024];
         sprintf(outFileName, "%s", targetFileName);
         sprintf(&outFileName[len - 4], "_offsets.txt");
-        FILE *fptr = fopen(outFileName, "w");
+        FILE *fptr = fopen(outFileName, "w+");
         if (fptr) {
             fprintf(fptr, "X Offset  Y Offset  Z Offset  Z RMS\n");
             fprintf(fptr, "%08.3f  %08.3f  %08.3f  %08.3f\n", result.tx, result.ty, result.tz, result.rms);


### PR DESCRIPTION
Writing the offsets text file failed if the file didn't already exist.
Update the fopen mode to allow creating the file. This fixes errors
like the following:

    Writing offsets text file.
    Failed to write /path/to/DATASET_offsets.txt